### PR TITLE
Merchant nav

### DIFF
--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -2,8 +2,15 @@
   <nav class="nav-bar">
     <div class="general-nav">
       <%= link_to "Home", welcome_path %>
-        <%= link_to "Browse Dishes", items_path %>
-        <%= link_to "Restaurants", merchants_path %>
+      <% if current_user %>
+        <% if current_user.registered? %>
+          <%= link_to "My Profile", profile_path %>
+        <% elsif current_user.merchant? %>
+          <%= link_to "My Dashboard", dashboard_path %>
+        <% end %>
+      <% end %>
+      <%= link_to "Browse Dishes", items_path %>
+      <%= link_to "Restaurants", merchants_path %>
     </div>
     <div class="auth-nav">
       <% if !current_user %>

--- a/spec/features/merchant/merchant_nav_spec.rb
+++ b/spec/features/merchant/merchant_nav_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "As a merchant", type: :feature do
     within ".general-nav" do
       expect(page).to have_link("Home")
       expect(page).to have_link("My Dashboard")
-      expect(page).to_not have_link("Browse Dishes")
-      expect(page).to_not have_link("Restaurants")
+      expect(page).to have_link("Browse Dishes")
+      expect(page).to have_link("Restaurants")
     end
 
     within ".auth-nav" do

--- a/spec/features/merchant/merchant_nav_spec.rb
+++ b/spec/features/merchant/merchant_nav_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
-RSpec.describe "As a registered user", type: :feature do
+RSpec.describe "As a merchant", type: :feature do
   it 'user sees appropriate nav bar links' do
-    user = User.create(name: "tester", email: "test@email.com", password: "test")
+    user = User.create(name: "tester", email: "test@email.com", password: "test", role: 1)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    visit profile_path
+    visit dashboard_path
 
     within ".general-nav" do
       expect(page).to have_link("Home")
-      expect(page).to have_link("My Profile")
-      expect(page).to have_link("Browse Dishes")
-      expect(page).to have_link("Restaurants")
+      expect(page).to have_link("My Dashboard")
+      expect(page).to_not have_link("Browse Dishes")
+      expect(page).to_not have_link("Restaurants")
     end
 
     within ".auth-nav" do
@@ -22,10 +22,9 @@ RSpec.describe "As a registered user", type: :feature do
     end
 
     within ".cart-nav" do
-      expect(page).to have_link("Cart")
+      expect(page).to_not have_link("Cart")
     end
 
     expect(page).to have_content("Logged in as #{user.name}")
-
   end
 end


### PR DESCRIPTION
As a merchant user
I see the same links as a visitor
Plus the following links:
- a link to my merchant dashboard ("/dashboard")
- a link to log out ("/logout")

Minus the following links/info:
- I do not see a link to log in or register
- a link to my shopping cart ("/cart") or count of cart items