### PR TITLE
Admin nav

### DIFF
--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -7,6 +7,9 @@
           <%= link_to "My Profile", profile_path %>
         <% elsif current_user.merchant? %>
           <%= link_to "My Dashboard", dashboard_path %>
+        <% elsif current_user.admin? %>
+          <%= link_to "Admin Dashboard", admin_dashboard_path %>
+          <%= link_to "Users", admin_users_path %>
         <% end %>
       <% end %>
       <%= link_to "Browse Dishes", items_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ post '/login', to: 'sessions#create'
 delete '/logout', to: 'sessions#destroy'
 
 get '/dashboard', to: 'merchants#show'
+get '/admin/dashboard', to: 'items#index'
 get '/dashboard/items', to: 'merchant/items#index'
 get '/profile', to: 'users#show'
 get '/profile/edit', to: 'users#edit'

--- a/spec/features/admin/admin_nav_spec.rb
+++ b/spec/features/admin/admin_nav_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "As an admin", type: :feature do
 
     within ".general-nav" do
       expect(page).to have_link("Home")
-      expect(page).to have_link("My Dashboard")
+      expect(page).to have_link("Admin Dashboard")
       expect(page).to have_link("Users")
       expect(page).to have_link("Browse Dishes")
       expect(page).to have_link("Restaurants")

--- a/spec/features/admin/admin_nav_spec.rb
+++ b/spec/features/admin/admin_nav_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "As an admin", type: :feature do
+  it 'user sees appropriate nav bar links' do
+    user = User.create(name: "tester", email: "test@email.com", password: "test", role: 2)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    within ".general-nav" do
+      expect(page).to have_link("Home")
+      expect(page).to have_link("My Dashboard")
+      expect(page).to have_link("Users")
+      expect(page).to have_link("Browse Dishes")
+      expect(page).to have_link("Restaurants")
+    end
+
+    within ".auth-nav" do
+      expect(page).to have_link("Log Out")
+      expect(page).to_not have_link("Log In")
+      expect(page).to_not have_link("Register")
+    end
+
+    within ".cart-nav" do
+      expect(page).to_not have_link("Cart")
+    end
+
+    expect(page).to have_content("Logged in as #{user.name}")
+  end
+end


### PR DESCRIPTION
As an admin user
I see the same links as a visitor
Plus the following links
- a link to see all users ("/admin/users")
- a link to my admin dashboard ("/admin/dashboard")
- a link to log out ("/logout")

Minus the following links/info:
- I do not see a link to log in or register
- a link to my shopping cart ("/cart") or count of cart items