### PR TITLE
module Helpers::Authentication

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-
+require 'support/helpers/authentication'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -45,6 +45,7 @@ DatabaseCleaner.strategy = :truncation
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.include Helpers::Authentication, type: :feature
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -1,0 +1,10 @@
+module Helpers
+  module Authentication
+    def login_as(user)
+      visit login_path
+      fill_in :email, with: user.email
+      fill_in :password, with: user.password
+      click_button 'Log In'
+    end
+  end
+end


### PR DESCRIPTION
Added module Helpers::Authentication to login_as(user)

from Ian on 1811_backend slack channel:

step 1, create /spec/support/helpers/authentication.rb and put the following code inside:
module Helpers
  module Authentication
    def login_as(user)
       visit login_path
       fill_in :email, with: user.email
       fill_in :password, with: user.password
       click_button 'Log in'
    end
  end
end

adjust the email/password fields as necessary for your login form to work

step 2, add the following line to your rails_helper.rb file where it says "# Add additional requires below this line"

require 'support/helpers/authentication'

step 3, also in your rails_helper.rb, inside the RSpec.configure block, add this line at the top:

RSpec.configure do |config|
  config.include Helpers::Authentication, type: :feature
  # leave everything else in this block as-is, just add the line above
end

step 4, in your tests, you should now be able to create a user object and use the new helper method to fill in the form and manually log in:

admin = create(:admin)
active_user = create(:user)
login_as(admin)
# do some stuff as the admin user
visit logout_path
login_as(active_user)
# check that active_user has whatever changes admin made to profile, making them active/inactive/etc