### PR TITLE
User's and Visitor's can add items to cart from item show page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,4 +237,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-
+  before_action :set_cart
   helper_method :current_user
 
   #Unhighlight if needed in view
@@ -36,6 +36,10 @@ class ApplicationController < ActionController::Base
     unless current_registered?
       render file: "/public/404", status: :not_found
     end
+  end
+
+  def set_cart
+    @cart ||= Cart.new(session[:cart])
   end
 
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,8 +1,8 @@
 class CartsController < ApplicationController
   def create
     item = Item.find(params[:item_id])
-    flash[:notice] = "1 #{item.name} has been added to your cart."
-    redirect_to visitor_items_path
+    flash[:notice] = "1 #{item.title} has been added to your cart."
+    redirect_to items_path
   end
 
   def show

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -1,6 +1,7 @@
 class CartsController < ApplicationController
   def create
     item = Item.find(params[:item_id])
+    @cart.add_item(item.id)
     flash[:notice] = "1 #{item.title} has been added to your cart."
     redirect_to items_path
   end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -2,7 +2,8 @@ class CartsController < ApplicationController
   def create
     item = Item.find(params[:item_id])
     @cart.add_item(item.id)
-    flash[:notice] = "1 #{item.title} has been added to your cart."
+    session[:cart] = @cart.contents
+    flash[:success] = "1 #{item.title} has been added to your cart."
     redirect_to items_path
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,10 +1,15 @@
 class Cart
+  attr_reader :contents
 
   def initialize(contents)
-    @contents = contents || Hash.new()
+    @contents = contents || Hash.new(0)
   end
 
   def total_count
     @contents.values.sum
+  end
+
+  def add_item(id)
+    @contents[id] += 1
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,0 +1,10 @@
+class Cart
+
+  def initialize(contents)
+    @contents = contents || Hash.new()
+  end
+
+  def total_count
+    @contents.values.sum
+  end
+end

--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -27,5 +27,6 @@
       <% if !current_user || current_user.registered? %>
         <%= link_to "Cart", cart_path %>
       <% end %>
+      <p>Cart: <%= @cart.total_count %> </p>
     </div>
   </nav>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,3 +1,7 @@
 <h1>My Cart</h1>
 
-<%= render 'itemlist' %>
+<% if @items.nil? %>
+  <p>Shopping cart is currently empty.</p>
+<% else %>
+  <%= render 'itemlist' %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,2 +1,4 @@
-<h2><%= @item.name %></h2>
-<p>Cost: <%= @item.cost %></p>
+<h2><%= @item.title %></h2>
+<p>Cost: <%= @item.price %></p>
+
+<%= button_to "Add Item To Cart", carts_path(item_id: @item.id) %>

--- a/spec/features/user/registered_user_nav_spec.rb
+++ b/spec/features/user/registered_user_nav_spec.rb
@@ -91,5 +91,5 @@ RSpec.describe "As a registered user", type: :feature do
     expect(current_path).to eq(cart_path)
     expect(page).to have_content("My cart")
   end
-  
+
 end

--- a/spec/features/user/registered_user_nav_spec.rb
+++ b/spec/features/user/registered_user_nav_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "As a registered user", type: :feature do
     click_link "Cart"
 
     expect(current_path).to eq(cart_path)
-    expect(page).to have_content("My cart")
+    expect(page).to have_content("My Cart")
   end
 
 end

--- a/spec/features/visitor_can_add_items_to_their_cart_spec.rb
+++ b/spec/features/visitor_can_add_items_to_their_cart_spec.rb
@@ -15,4 +15,17 @@ RSpec.describe 'From an items show page' do
       expect(page).to have_content("Cart: 1")
     end
   end
+
+  context 'as a registered user' do
+    it 'can add an item to their cart' do
+      user = create(:user, password: 'test', username: '')
+      visit item_path(@item)
+
+      click_button "Add Item To Cart"
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("1 #{@item.title} has been added to your cart.")
+      expect(page).to have_content("Cart: 1")
+    end
+  end
 end

--- a/spec/features/visitor_can_add_items_to_their_cart_spec.rb
+++ b/spec/features/visitor_can_add_items_to_their_cart_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'From an items show page' do
+  before :each do
+    @item = create(:item)
+  end
+  context 'as a visitor' do
+    it 'can add an item to their cart' do
+      visit item_path(@item)
+
+      click_button "Add Item To Cart"
+
+      expect(current_path).to eq(items_path)
+      expect(page).to have_content("1 #{@item.title} has been added to your cart.")
+      expect(page).to have_content("Cart: 1")
+    end
+  end
+end

--- a/spec/features/visitor_can_add_items_to_their_cart_spec.rb
+++ b/spec/features/visitor_can_add_items_to_their_cart_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe 'From an items show page' do
 
   context 'as a registered user' do
     it 'can add an item to their cart' do
-      user = create(:user, password: 'test', username: '')
+      user = create(:user, password: 'test', email: 'email@email.com', role: 0)
+      visit login_path
+      fill_in :email, with: user.email
+      fill_in :password, with: user.password
+      click_button "Log In"
+
       visit item_path(@item)
 
       click_button "Add Item To Cart"

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Cart do
+  describe '#total_count' do
+    it 'can calculate the total number of items it holds' do
+    cart = Cart.new({
+        1 => 2,
+        2 => 3
+        })
+
+      expect(cart.total_count).to eq(5)
+    end
+  end
+end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -11,4 +11,19 @@ RSpec.describe Cart do
       expect(cart.total_count).to eq(5)
     end
   end
+
+  describe '#add_item' do
+    it 'should add an item to our cart' do
+      cart = Cart.new({
+        1 => 2,
+        2 => 3
+        })
+
+      cart.add_item(1)
+      cart.add_item(2)
+
+      expect(cart.contents).to eq({1 => 3, 2 => 4})
+    end
+  end
+  
 end


### PR DESCRIPTION
As a visitor or registered user
When I visit an item's show page from the items catalog
I see a link or button to add this item to my cart
And I click its link or button
I am returned to the item index page
I see a flash message indicating the item has been added to my cart
The navigation bar increments my cart counter