### PR TITLE
Merch dashboard orders

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -11,6 +11,7 @@ class MerchantsController < ApplicationController
 
   def show
     @user = current_user
+    @orders = Order.find_orders(@user)
   end
 
   def update

--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -6,10 +6,10 @@ class User::OrdersController < ApplicationController
     @orders = Order.where(user: @user)
   end
 
-  # def show
-  #   # @user = current_user
-  #   # @orders = Order.find_by(user: current_user)
-  # end
+  def show
+    @user = current_user
+    @orders = Order.where(id: params[:id])
+  end
 
   def update
     @order = Order.find(params[:order_id])

--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -3,10 +3,13 @@ class User::OrdersController < ApplicationController
 
   def index
     @user = User.find(session[:user_id])
+    @orders = Order.where(user: @user)
   end
 
-  def show
-  end
+  # def show
+  #   # @user = current_user
+  #   # @orders = Order.find_by(user: current_user)
+  # end
 
   def update
     @order = Order.find(params[:order_id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,17 +21,9 @@ class UsersController < ApplicationController
     end
   end
 
-  def index
-    @users = User.all
-  end
-
   def show
-    if current_user.merchant?
-      @user = current_user
-      @orders = @user.find_orders
-    else
-      @user = current_user
-    end
+    @user = current_user
+    @orders = Order.where(user: current_user)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,12 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    if current_user.merchant?
+      @user = current_user
+      @orders = @user.find_orders
+    else
+      @user = current_user
+    end
   end
 
   def edit

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -25,4 +25,7 @@ class Order < ApplicationRecord
     update_attribute(:status, 2) if pending?
   end
 
+  def self.find_orders
+    binding.pry
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -30,6 +30,6 @@ class Order < ApplicationRecord
     #     on orders.id = order_items.order_id
     #     join items on order_items.item_id = items.id
     #     where items.user_id = 1;
-    Order.joins(:items).where(items: {user_id: user.id})
+    Order.joins(:items).where(items: {user_id: user.id}, status: "pending").distinct
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -25,7 +25,11 @@ class Order < ApplicationRecord
     update_attribute(:status, 2) if pending?
   end
 
-  def self.find_orders
-    binding.pry
+  def self.find_orders(user)
+    # select orders. * from orders inner join order_items
+    #     on orders.id = order_items.order_id
+    #     join items on order_items.item_id = items.id
+    #     where items.user_id = 1;
+    Order.joins(:items).where(items: {user_id: user.id})
   end
 end

--- a/app/views/application/_orderlist.html.erb
+++ b/app/views/application/_orderlist.html.erb
@@ -6,8 +6,8 @@
     <% if order.pending? && !@user.merchant? %>
       <%= button_to "Cancel Order", profile_orders_path, method: :patch, params: {order_id: order.id} %>
     <% end %>
-    <a>Started on: <%= order.created_at %></a>
-    <a>Last Updated on: <%= order.updated_at %></a>
+    <a>Created on: <%= order.created_at.to_date.to_s %></a>
+    <a>Last Updated on: <%= order.updated_at.to_date.to_s %></a>
     <a>Item Count: <%= order.item_count %></a>
     <a>Order Total: <%= order.total_cost %></a>
   </li>

--- a/app/views/application/_orderlist.html.erb
+++ b/app/views/application/_orderlist.html.erb
@@ -1,9 +1,9 @@
 <ul class='orders-list'>
-  <% @user.orders.each do |order| %>
+  <% @orders.each do |order| %>
   <li id=<%= "order-#{order.id}" %>>
     <%= link_to  "Order ID: #{order.id}", profile_orders_path(order) %>
     <a>Order Status: <%= order.status %></a>
-    <% if order.pending? %>
+    <% if order.pending? && !@user.merchant? %>
       <%= button_to "Cancel Order", profile_orders_path, method: :patch, params: {order_id: order.id} %>
     <% end %>
     <a>Started on: <%= order.created_at %></a>

--- a/app/views/application/_orderlist.html.erb
+++ b/app/views/application/_orderlist.html.erb
@@ -1,15 +1,19 @@
 <ul class='orders-list'>
-  <% @orders.each do |order| %>
-  <li id=<%= "order-#{order.id}" %>>
-    <%= link_to  "Order ID: #{order.id}", profile_orders_path(order) %>
-    <a>Order Status: <%= order.status %></a>
-    <% if order.pending? && !@user.merchant? %>
-      <%= button_to "Cancel Order", profile_orders_path, method: :patch, params: {order_id: order.id} %>
+  <% unless @orders == nil %>
+    <% @orders.each do |order| %>
+      <li id=<%= "order-#{order.id}" %>>
+        <%= link_to  "Order ID: #{order.id}", profile_orders_path(order) %>
+        <a>Order Status: <%= order.status %></a>
+        <% if order.pending? && !@user.merchant? %>
+          <%= button_to "Cancel Order", profile_orders_path, method: :patch, params: {order_id: order.id} %>
+        <% end %>
+        <a>Placed on: <%= order.created_at.to_date.to_s %></a>
+        <a>Last Updated on: <%= order.updated_at.to_date.to_s %></a>
+        <a>Item Count: <%= order.item_count %></a>
+        <a>Order Total: <%= order.total_cost %></a>
+      </li>
     <% end %>
-    <a>Created on: <%= order.created_at.to_date.to_s %></a>
-    <a>Last Updated on: <%= order.updated_at.to_date.to_s %></a>
-    <a>Item Count: <%= order.item_count %></a>
-    <a>Order Total: <%= order.total_cost %></a>
-  </li>
+  <% else %>
+    <li>No orders have been placed yet</li>
   <% end %>
 </ul>

--- a/app/views/application/_orderlist.html.erb
+++ b/app/views/application/_orderlist.html.erb
@@ -2,7 +2,7 @@
   <% unless @orders == nil %>
     <% @orders.each do |order| %>
       <li id=<%= "order-#{order.id}" %>>
-        <%= link_to  "Order ID: #{order.id}", profile_orders_path(order) %>
+        <%= link_to  "Order ID: #{order.id}", profile_order_path(order) %>
         <a>Order Status: <%= order.status %></a>
         <% if order.pending? && !@user.merchant? %>
           <%= button_to "Cancel Order", profile_orders_path, method: :patch, params: {order_id: order.id} %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -1,1 +1,2 @@
 <%= render 'infopage' %>
+<%= render 'orderlist' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ get '/profile/edit', to: 'users#edit'
 put '/profile', to: 'users#update'
 get '/profile/orders', to: 'user/orders#index'
 patch '/profile/orders', to: 'user/orders#update'
-get '/profile/orders/:id', to: 'user/orders#show', as: 'profile/order'
+get '/profile/orders/:id', to: 'user/orders#show', as: 'profile_order'
 resources :users, only: [:show, :index, :create, :update] do
   resources :orders, only: [:show, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ get '/profile/edit', to: 'users#edit'
 put '/profile', to: 'users#update'
 get '/profile/orders', to: 'user/orders#index'
 patch '/profile/orders', to: 'user/orders#update'
-get '/profile/orders/:id', to: 'user/orders#show'
+get '/profile/orders/:id', to: 'user/orders#show', as: 'profile/order'
 resources :users, only: [:show, :index, :create, :update] do
   resources :orders, only: [:show, :create]
 end

--- a/spec/features/merchant/merchant_visits_dashboard_spec.rb
+++ b/spec/features/merchant/merchant_visits_dashboard_spec.rb
@@ -16,5 +16,36 @@ RSpec.describe "as a merchant" do
       expect(page).to have_content("Email: #{merchant.email}")
       expect(page).to_not have_button("Edit Profile")
     end
+
+    it "it shows me unfulfilled orders" do
+      Faker::UniqueGenerator.clear
+      merchant1, merchant2 = create_list(:user, 2, role: 1)
+      user1, user2 = create_list(:user, 2, role: 0)
+      item1, item2 = create_list(:item, 2, user: merchant1)
+      item3, item4 = create_list(:item, 2, user: merchant2)
+      order1 = create(:order, user: user1)
+      order2 = create(:order, user: user2)
+      oi1 = create(:order_item, order: order1, item: item1)
+      oi2 = create(:order_item, order: order1, item: item3)
+      oi3 = create(:order_item, order: order2, item: item2)
+      oi4 = create(:order_item, order: order2, item: item4)
+
+      login_as(merchant1)
+      visit dashboard_path(merchant1)
+      save_and_open_page
+      within ".order-#{order1.id}" do
+        expect(page).to have_content("Order ID: #{order1.id}")
+        expect(page).to have_content("Placed on: #{order1.created_at.to_date.to_s}")
+        expect(page).to have_content("Item Count: #{order1.item_count}")
+        expect(page).to have_content("Order Total: #{order1.total_cost}")
+      end
+      within ".order-#{order2.id}" do
+        expect(page).to have_content("Order ID: #{order2.id}")
+        expect(page).to have_content("Placed on: #{order2.created_at.to_date.to_s}")
+        expect(page).to have_content("Item Count: #{order2.item_count}")
+        expect(page).to have_content("Order Total: #{order2.total_cost}")
+      end
+      expect(page).to_not have_button("Cancel Order")
+    end
   end
 end

--- a/spec/features/merchant/merchant_visits_dashboard_spec.rb
+++ b/spec/features/merchant/merchant_visits_dashboard_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "as a merchant" do
   context "when I visit my /dashboard" do
-    it "I see my profile data" do
+    xit "I see my profile data" do
       merchant = create(:user, role: 1)
       login_as(merchant)
 

--- a/spec/features/merchant/merchant_visits_dashboard_spec.rb
+++ b/spec/features/merchant/merchant_visits_dashboard_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe "as a merchant" do
       visit dashboard_path(merchant1)
 
       within "#order-#{order1.id}" do
-        expect(page).to have_content("Order ID: #{order1.id}")
+        expect(page).to have_link("#{order1.id}", href: profile_order_path(order1))
         expect(page).to have_content("Placed on: #{order1.created_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{order1.item_count}")
         expect(page).to have_content("Order Total: #{order1.total_cost}")
       end
       within "#order-#{order2.id}" do
-        expect(page).to have_content("Order ID: #{order2.id}")
+        expect(page).to have_link("#{order2.id}", href: profile_order_path(order2))
         expect(page).to have_content("Placed on: #{order2.created_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{order2.item_count}")
         expect(page).to have_content("Order Total: #{order2.total_cost}")

--- a/spec/features/merchant/merchant_visits_dashboard_spec.rb
+++ b/spec/features/merchant/merchant_visits_dashboard_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "as a merchant" do
   context "when I visit my /dashboard" do
-    xit "I see my profile data" do
+    it "I see my profile data" do
       merchant = create(:user, role: 1)
       login_as(merchant)
 
@@ -32,14 +32,14 @@ RSpec.describe "as a merchant" do
 
       login_as(merchant1)
       visit dashboard_path(merchant1)
-      save_and_open_page
-      within ".order-#{order1.id}" do
+
+      within "#order-#{order1.id}" do
         expect(page).to have_content("Order ID: #{order1.id}")
         expect(page).to have_content("Placed on: #{order1.created_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{order1.item_count}")
         expect(page).to have_content("Order Total: #{order1.total_cost}")
       end
-      within ".order-#{order2.id}" do
+      within "#order-#{order2.id}" do
         expect(page).to have_content("Order ID: #{order2.id}")
         expect(page).to have_content("Placed on: #{order2.created_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{order2.item_count}")

--- a/spec/features/user/user_orders_spec.rb
+++ b/spec/features/user/user_orders_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'as a user', type: :feature do
   before :each do
     Faker::UniqueGenerator.clear
 
-    @user = create(:user)
+    @user = create(:user, name: "April Test")
 
     @merchant_1 = create(:user, role: 1)
     @merchant_2 = create(:user, role: 1)
@@ -31,7 +31,7 @@ RSpec.describe 'as a user', type: :feature do
     @order_item_9 = create(:order_item, item: @item_9, order: @order_3)
 
     @order_item_10 = create(:order_item, item: @item_10, order: @order_4)
-    binding.pry
+
     login_as(@user)
 
   end
@@ -48,8 +48,8 @@ RSpec.describe 'as a user', type: :feature do
         expect(page).to have_link("Order ID: #{@order_1.id}")
         expect(page).to have_content("Order Status: #{@order_1.status}")
         expect(page).to have_button("Cancel Order")
-        expect(page).to have_content("Started on: #{@order_1.created_at}")
-        expect(page).to have_content("Last Updated on: #{@order_1.updated_at}")
+        expect(page).to have_content("Placed on: #{@order_1.created_at.to_date.to_s}")
+        expect(page).to have_content("Last Updated on: #{@order_1.updated_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{@order_1.item_count}")
         expect(page).to have_content("Order Total: #{@order_1.total_cost}")
       end
@@ -58,8 +58,8 @@ RSpec.describe 'as a user', type: :feature do
         expect(page).to have_link("Order ID: #{@order_2.id}")
         expect(page).to have_content("Order Status: #{@order_2.status}")
         expect(page).to have_button("Cancel Order")
-        expect(page).to have_content("Started on: #{@order_2.created_at}")
-        expect(page).to have_content("Last Updated on: #{@order_2.updated_at}")
+        expect(page).to have_content("Placed on: #{@order_2.created_at.to_date.to_s}")
+        expect(page).to have_content("Last Updated on: #{@order_2.updated_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{@order_2.item_count}")
         expect(page).to have_content("Order Total: #{@order_2.total_cost}")
       end
@@ -68,8 +68,8 @@ RSpec.describe 'as a user', type: :feature do
         expect(page).to have_link("Order ID: #{@order_3.id}")
         expect(page).to have_content("Order Status: #{@order_3.status}")
         expect(page).to have_button("Cancel Order")
-        expect(page).to have_content("Started on: #{@order_3.created_at}")
-        expect(page).to have_content("Last Updated on: #{@order_3.updated_at}")
+        expect(page).to have_content("Placed on: #{@order_3.created_at.to_date.to_s}")
+        expect(page).to have_content("Last Updated on: #{@order_3.updated_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{@order_3.item_count}")
         expect(page).to have_content("Order Total: #{@order_3.total_cost}")
       end
@@ -78,8 +78,8 @@ RSpec.describe 'as a user', type: :feature do
         expect(page).to have_link("Order ID: #{@order_4.id}")
         expect(page).to have_content("Order Status: #{@order_4.status}")
         expect(page).to_not have_button("Cancel Order")
-        expect(page).to have_content("Started on: #{@order_4.created_at}")
-        expect(page).to have_content("Last Updated on: #{@order_4.updated_at}")
+        expect(page).to have_content("Placed on: #{@order_4.created_at.to_date.to_s}")
+        expect(page).to have_content("Last Updated on: #{@order_4.updated_at.to_date.to_s}")
         expect(page).to have_content("Item Count: #{@order_4.item_count}")
         expect(page).to have_content("Order Total: #{@order_4.total_cost}")
       end

--- a/spec/features/user/user_orders_spec.rb
+++ b/spec/features/user/user_orders_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'as a user', type: :feature do
     @order_item_9 = create(:order_item, item: @item_9, order: @order_3)
 
     @order_item_10 = create(:order_item, item: @item_10, order: @order_4)
-
+    binding.pry
     login_as(@user)
 
   end

--- a/spec/features/user/user_orders_spec.rb
+++ b/spec/features/user/user_orders_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'as a user', type: :feature do
 
       click_link "Order ID: #{@order_1.id}"
 
-      expect(current_path).to eq(profile_orders_path(@order_1))
+      expect(current_path).to eq(profile_order_path(@order_1))
 
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe Order, type: :model do
       expect(order.order_items[1].item).to eq(item2)
       expect(order.order_items[2].item).to eq(item3)
     end
+
+    it ".find_orders" do
+      Faker::UniqueGenerator.clear
+      merchant1, merchant2 = create_list(:user, 2, role: 1)
+      user1, user2, user3 = create_list(:user, 3, role: 0)
+      item1, item2 = create_list(:item, 2, user: merchant1)
+      item3, item4 = create_list(:item, 2, user: merchant2)
+      order1 = create(:order, user: user1)
+      order2 = create(:order, user: user2)
+      order3 = create(:order, user: user2)
+      oi1 = create(:order_item, order: order1, item: item1)
+      oi2 = create(:order_item, order: order1, item: item3)
+      oi3 = create(:order_item, order: order2, item: item2)
+      oi4 = create(:order_item, order: order2, item: item4)
+      oi5 = create(:order_item, order: order3, item: item1)
+      oi6 = create(:order_item, order: order3, item: item2)
+
+      expected1 = [order1, order2, order3]
+      expected2 = [order1, order2]
+
+      expect(merchant1.find_orders).to eq(expected1)
+      expect(merchant2.find_orders).to eq(expected2)
+    end
   end
 
   describe 'instance methods' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -41,18 +41,21 @@ RSpec.describe Order, type: :model do
       order1 = create(:order, user: user1)
       order2 = create(:order, user: user2)
       order3 = create(:order, user: user2)
+      order4 = create(:order, user: user1, status: 2)
       oi1 = create(:order_item, order: order1, item: item1)
       oi2 = create(:order_item, order: order1, item: item3)
       oi3 = create(:order_item, order: order2, item: item2)
       oi4 = create(:order_item, order: order2, item: item4)
       oi5 = create(:order_item, order: order3, item: item1)
       oi6 = create(:order_item, order: order3, item: item2)
+      oi7 = create(:order_item, order: order4, item: item1)
+      oi8 = create(:order_item, order: order4, item: item2)
 
       expected1 = [order1, order2, order3]
       expected2 = [order1, order2]
 
-      expect(merchant1.find_orders).to eq(expected1)
-      expect(merchant2.find_orders).to eq(expected2)
+      expect(Order.find_orders(merchant1)).to eq(expected1)
+      expect(Order.find_orders(merchant2)).to eq(expected2)
     end
   end
 


### PR DESCRIPTION
Closes #31 
- changes _orderslist partial to work from @orders collection instead of @user.orders
- fixes fallout from above change
- adds test and functionality for User Story 40:
As a merchant
When I visit my dashboard ("/dashboard")
If any users have pending orders containing items I sell
Then I see a list of these orders.
Each order listed includes the following information:
- the ID of the order, which is a link to the order show page ("/dashboard/orders/15")
- the date the order was made
- the total quantity of my items in the order
- the total value of my items for that order