### PR TITLE
Merchant fulfillment

### DIFF
--- a/app/controllers/merchants/order_items_controller.rb
+++ b/app/controllers/merchants/order_items_controller.rb
@@ -1,0 +1,6 @@
+class Merchants::OrderItemsController < Merchants::BaseController
+
+  def update
+    binding.pry
+  end
+end

--- a/app/controllers/merchants/order_items_controller.rb
+++ b/app/controllers/merchants/order_items_controller.rb
@@ -1,6 +1,9 @@
 class Merchants::OrderItemsController < Merchants::BaseController
 
   def update
-    binding.pry
+    order_item = OrderItem.find(params[:id])
+    order_item.fulfill_order_item
+    flash[:success] = "Your item has been fulfilled."
+    redirect_to dashboard_order_path(order_item.order)
   end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -24,7 +24,11 @@ class MerchantsController < ApplicationController
     @user = User.find(params[:id])
     @user.change_status
     redirect_to admin_merchants_path
-    flash[:success] = "#{@user.name} has been disabled."
+    if @user.inactive?
+      flash[:success] = "#{@user.name} has been disabled."
+    elsif @user.active?
+      flash[:success] = "#{@user.name} has been re-enabled."
+    end
   end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,5 +45,4 @@ class Order < ApplicationRecord
              .where(items: {user_id: user}, order_id: id)
   end
 
-
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -23,7 +23,10 @@ class OrderItem < ApplicationRecord
     item.quantity >= self.quantity
   end
 
-  def fulfull_order_item
+  def fulfill_order_item
+    update_attribute(:fulfillment_status, 1)
+    new_quantity = item.quantity - quantity
+    item.update_attribute(:quantity, new_quantity)
   end
 
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -20,7 +20,7 @@ class OrderItem < ApplicationRecord
   end
 
   def in_stock?
-    quantity >= item.quantity
+    item.quantity >= self.quantity
   end
 
   def fulfull_order_item

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -19,4 +19,11 @@ class OrderItem < ApplicationRecord
     self.fulfillment_status = 2
   end
 
+  def in_stock?
+    quantity >= item.quantity
+  end
+
+  def fulfull_order_item
+  end
+
 end

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -24,6 +24,9 @@
         <p>Qty: <%= order_item.quantity %></p>
         <p>Item Subtotal: <%= number_to_currency(order_item.subtotal) %></p>
         <p>Order Status: <%= order_item.fulfillment_status.capitalize %></p>
+        <% if order_item.fulfillment_status == "pending" %>
+          <%= button_to "Fulfill Item", dashboard_order_item_path(order_item) %>
+        <% end %>
       </section>
     </section>
   <% end %>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -23,9 +23,9 @@
         <p>Price: <%= number_to_currency(order_item.sale_price) %></p>
         <p>Qty: <%= order_item.quantity %></p>
         <p>Item Subtotal: <%= number_to_currency(order_item.subtotal) %></p>
-        <p>Order Status: <%= order_item.fulfillment_status.capitalize %></p>
-        <% if order_item.fulfillment_status.pending? && order_item.in_stock? %>
-          <%= button_to "Fulfill Item", dashboard_order_item_path(order_item) %>
+        <p>Order Item Status: <%= order_item.fulfillment_status.capitalize %></p>
+        <% if order_item.pending? && order_item.in_stock? %>
+          <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), method: :patch %>
         <% end %>
       </section>
     </section>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -24,7 +24,7 @@
         <p>Qty: <%= order_item.quantity %></p>
         <p>Item Subtotal: <%= number_to_currency(order_item.subtotal) %></p>
         <p>Order Status: <%= order_item.fulfillment_status.capitalize %></p>
-        <% if order_item.fulfillment_status == "pending" %>
+        <% if order_item.fulfillment_status.pending? && order_item.in_stock? %>
           <%= button_to "Fulfill Item", dashboard_order_item_path(order_item) %>
         <% end %>
       </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ get '/dashboard', to: 'merchants#show'
 get '/dashboard/items', to: 'merchants/items#index'
 put '/dashboard/items/:id/edit', to: "merchants/items#edit", as: 'dashboard_item'
 get '/dashboard/orders/:id', to: 'merchants/orders#show', as: 'dashboard_order'
+patch '/dashboard/orderitems/:id', to: 'merchants/order_items#update', as: 'dashboard_order_item'
 
 # get '/merchants', to: 'users#index'
 resources :merchants, only: [:index, :update]

--- a/spec/features/admin/admin_can_enable_merchant_spec.rb
+++ b/spec/features/admin/admin_can_enable_merchant_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "As an admin", type: :feature do
+  it 'I can enable merchants who were disabled, and they can log in' do
+    Faker::UniqueGenerator.clear
+    @admin1 = create(:user, role: 2, name: "Admin")
+    @merchant1 = create(:user, role: 1, name: "Merchant", activation_status: 1)
+    @merchant2, @merchant3 = create_list(:user, 2, role: 1)
+    #Attempt to log in as a merchabt
+    visit login_path
+    fill_in "Email", with: "#{@merchant1.email}"
+    fill_in "Password", with: "#{@merchant1.password}"
+    click_button "Log In"
+    expect(current_path).to eq(login_path)
+    expect(page).to have_content("This account has been disabled. Please contact an administrator to log in.")
+
+    #Log in as admin and re-activate the merchant
+    login_as(@admin1)
+    visit admin_merchants_path
+    save_and_open_page
+    within ".user-#{@merchant1.id}-row" do
+      click_button("Enable")
+    end
+    expect(page).to have_content("#{@merchant1.name} has been re-enabled")
+    within ".user-#{@merchant1.id}-row" do
+      expect(page).to have_button("Disable")
+    end
+    click_on("Log Out")
+
+    #Merchant successfully logs in again
+    login_as(@merchant1)
+    expect(current_path).to eq(dashboard_path)
+    expect(page).to have_content("#{@merchant1.name}")
+  end
+end

--- a/spec/features/merchant/merchant_fulfills_order_items_spec.rb
+++ b/spec/features/merchant/merchant_fulfills_order_items_spec.rb
@@ -1,28 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe "as a merchant" do
-  before :each do
-    Faker::UniqueGenerator.clear
-    @user = create(:user)
-    @merchant = create(:user, role: 1)
-    @merchant_2 = create(:user, role: 1)
-    @order = create(:order, user: @user)
-    @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 5, price: 5)
-    @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 5, price: 5)
-    @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
-    @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
-    @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
-    @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 3)
-    @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 6)
-    @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 6)
-    @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
-
-    login_as(@merchant)
-    visit dashboard_order_path(@order)
-  end
-
   context "if the item has already been fulfilled" do
     it "it is listed as fulfilled" do
+      Faker::UniqueGenerator.clear
+      @user = create(:user)
+      @merchant = create(:user, role: 1)
+      @merchant_2 = create(:user, role: 1)
+      @order = create(:order, user: @user)
+      @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 5, price: 5)
+      @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 5, price: 5)
+      @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
+      @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
+      @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
+      @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 3)
+      @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 6)
+      @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 6)
+      @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
+
+      login_as(@merchant)
+      visit dashboard_order_path(@order)
+
       within ".item-#{@oi1.id}" do
         expect(page).to have_button("Fulfill Item")
       end
@@ -36,6 +34,24 @@ RSpec.describe "as a merchant" do
   end
   context "when I do not enough in-stock quantity" do
     it 'I can not fulfill an order-item' do
+      Faker::UniqueGenerator.clear
+      @user = create(:user)
+      @merchant = create(:user, role: 1)
+      @merchant_2 = create(:user, role: 1)
+      @order = create(:order, user: @user)
+      @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 5, price: 5)
+      @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 5, price: 5)
+      @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
+      @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
+      @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
+      @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 3)
+      @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 6)
+      @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 6)
+      @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
+
+      login_as(@merchant)
+      visit dashboard_order_path(@order)
+
       within ".item-#{@oi4.id}" do
         expect(page).to_not have_button("Fulfill Item")
       end
@@ -44,36 +60,48 @@ RSpec.describe "as a merchant" do
       end
     end
   end
+
   context "when I have the quantity in stock, I can fulfill an item" do
     it "by changing the oi status and reducing the item's quantity" do
+      Faker::UniqueGenerator.clear
+      @user = create(:user)
+      @merchant = create(:user, role: 1)
+      @merchant_2 = create(:user, role: 1)
+      @order = create(:order, user: @user)
+      @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 5, price: 5)
+      @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 5, price: 5)
+      @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
+      @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
+      @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
+      @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 3)
+      @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 6)
+      @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 6)
+      @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
+
+      login_as(@merchant)
+      visit dashboard_order_path(@order)
+
       within ".item-#{@oi1.id}" do
         click_button "Fulfill Item"
+      end
         expect(current_path).to eq(dashboard_order_path(@order))
-        expect(page).to have_content("Fulfilled")
         expect(@oi1.item.quantity).to eq(0)
         expect(@oi1.fulfilled?).to eq(true)
-      end
-      within ".item-#{@oi3.id}" do
-        click_button "Fulfill Item"
-        expect(current_path).to eq(dashboard_order_path(@order))
-        expect(page).to have_content("Fulfilled")
-        expect(@oi3.item.quantity).to eq(2)
-        expect(@oi3.fulfilled?).to eq(true)
+        expect(page).to have_content("Your item has been fulfilled.")
+      within ".item-#{@oi1.id}" do
+        expect(page).to have_content("Order Item Status: Fulfilled")
       end
 
+      within ".item-#{@oi3.id}" do
+        click_button "Fulfill Item"
+      end
+        expect(current_path).to eq(dashboard_order_path(@order))
+        expect(@oi3.item.quantity).to eq(2)
+        expect(@oi3.fulfilled?).to eq(true)
+        expect(page).to have_content("Your item has been fulfilled.")
+      within ".item-#{@oi3.id}" do
+        expect(page).to have_content("Order Item Status: Fulfilled")
+      end
     end
   end
 end
-
-
-
-#       When I visit an order show page from my dashboard
-# For each item of mine in the order
-# If the user's desired quantity is equal to or less than my current inventory quantity for that item
-# And I have not already "fulfilled" that item:
-# - Then I see a button or link to "fulfill" that item
-# - When I click on that link or button I am returned to the order show page
-# - I see the item is now fulfilled
-# - I also see a flash message indicating that I have fulfilled that item
-# - My inventory quantity is permanently reduced by the user's desired quantity
-#If I have already fulfilled this item, I see text indicating such.

--- a/spec/features/merchant/merchant_fulfills_order_items_spec.rb
+++ b/spec/features/merchant/merchant_fulfills_order_items_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "as a merchant" do
+  before :each do
+    Faker::UniqueGenerator.clear
+    @user = create(:user)
+    @merchant = create(:user, role: 1)
+    @merchant_2 = create(:user, role: 1)
+    @order = create(:order, user: @user)
+    @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 10, price: 5)
+    @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 10, price: 5)
+    @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
+    @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
+    @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
+    @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 5)
+    @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 5)
+    @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 5)
+    @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
+
+    login_as(@merchant)
+    visit dashboard_order_path(@order)
+  end
+
+  context "if the item has already been fulfilled" do
+    it "it is listed as fulfilled" do
+      within ".item-#{@oi1.id}" do
+        expect(page).to have_button("Fulfill Item")
+      end
+      within ".item-#{@oi2.id}" do
+        expect(page).to_not have_button("Fulfill Item")
+      end
+      within ".item-#{@oi3.id}" do
+        expect(page).to have_button("Fulfill Item")
+      end
+    end
+  end
+  context "when I have enough in-stock quantity" do
+    it 'I can fulfill an order-item' do
+
+    end
+  end
+  context "if I do not have enough quantity" do
+    it "I do something else" do
+    end
+  end
+end
+
+
+
+#       When I visit an order show page from my dashboard
+# For each item of mine in the order
+# If the user's desired quantity is equal to or less than my current inventory quantity for that item
+# And I have not already "fulfilled" that item:
+# - Then I see a button or link to "fulfill" that item
+# - When I click on that link or button I am returned to the order show page
+# - I see the item is now fulfilled
+# - I also see a flash message indicating that I have fulfilled that item
+# - My inventory quantity is permanently reduced by the user's desired quantity
+#If I have already fulfilled this item, I see text indicating such.

--- a/spec/features/merchant/merchant_fulfills_order_items_spec.rb
+++ b/spec/features/merchant/merchant_fulfills_order_items_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "as a merchant" do
       end
     end
   end
-  context "when I do not enough in-stock quantity" do
+  context "when I do not have enough in-stock quantity" do
     it 'I can not fulfill an order-item' do
       Faker::UniqueGenerator.clear
       @user = create(:user)

--- a/spec/features/merchant/merchant_fulfills_order_items_spec.rb
+++ b/spec/features/merchant/merchant_fulfills_order_items_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "as a merchant" do
     @merchant = create(:user, role: 1)
     @merchant_2 = create(:user, role: 1)
     @order = create(:order, user: @user)
-    @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 10, price: 5)
-    @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 10, price: 5)
+    @i1, @i2, @i3 = create_list(:item, 3, user: @merchant, quantity: 5, price: 5)
+    @i4, @i5 = create_list(:item, 2, user: @merchant_2, quantity: 5, price: 5)
     @oi1, @oi2, @oi3, @oi4, @oi5 = create_list(:order_item, 5)
     @oi1.update(order: @order, item: @i1, sale_price: 2, quantity: 5)
     @oi2.update(order: @order, item: @i2, sale_price: 3, quantity: 5, fulfillment_status: 1)
-    @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 5)
-    @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 5)
-    @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 5)
+    @oi3.update(order: @order, item: @i3, sale_price: 4, quantity: 3)
+    @oi4.update(order: @order, item: @i4, sale_price: 5, quantity: 6)
+    @oi5.update(order: @order, item: @i5, sale_price: 6, quantity: 6)
     @order_items = [@oi1, @oi2, @oi3, @oi4, @oi5]
 
     login_as(@merchant)
@@ -34,13 +34,33 @@ RSpec.describe "as a merchant" do
       end
     end
   end
-  context "when I have enough in-stock quantity" do
-    it 'I can fulfill an order-item' do
-
+  context "when I do not enough in-stock quantity" do
+    it 'I can not fulfill an order-item' do
+      within ".item-#{@oi4.id}" do
+        expect(page).to_not have_button("Fulfill Item")
+      end
+      within ".item-#{@oi5.id}" do
+        expect(page).to_not have_button("Fulfill Item")
+      end
     end
   end
-  context "if I do not have enough quantity" do
-    it "I do something else" do
+  context "when I have the quantity in stock, I can fulfill an item" do
+    it "by changing the oi status and reducing the item's quantity" do
+      within ".item-#{@oi1.id}" do
+        click_button "Fulfill Item"
+        expect(current_path).to eq(dashboard_order_path(@order))
+        expect(page).to have_content("Fulfilled")
+        expect(@oi1.item.quantity).to eq(0)
+        expect(@oi1.fulfilled?).to eq(true)
+      end
+      within ".item-#{@oi3.id}" do
+        click_button "Fulfill Item"
+        expect(current_path).to eq(dashboard_order_path(@order))
+        expect(page).to have_content("Fulfilled")
+        expect(@oi3.item.quantity).to eq(2)
+        expect(@oi3.fulfilled?).to eq(true)
+      end
+
     end
   end
 end

--- a/spec/models/order_items_spec.rb
+++ b/spec/models/order_items_spec.rb
@@ -49,34 +49,69 @@ RSpec.describe OrderItem, type: :model do
       expect(item2.quantity).to eq(7)
 
     end
+    context "when trying to fulfill order_items" do
+      before :each do
+        Faker::UniqueGenerator.clear
+        @user = create(:user)
+        @merchant = create(:user, role: 1)
+        @item_1, @item_2, @item_3, @item_4, @item_5, @item_6, @item_7, @item_8, @item_9, @item_10 = create_list(:item, 10, user: @merchant, quantity: 5)
+        @order = create(:order, user: @user)
+        @order_item_1 = create(:order_item, item: @item_1, order: @order, sale_price: 5, quantity: 1)
+        @order_item_2 = create(:order_item, item: @item_2, order: @order, sale_price: 5, quantity: 2)
+        @order_item_3 = create(:order_item, item: @item_3, order: @order, sale_price: 5, quantity: 7)
+        @order_item_4 = create(:order_item, item: @item_4, order: @order, sale_price: 5, quantity: 4)
+        @order_item_5 = create(:order_item, item: @item_5, order: @order, sale_price: 5, quantity: 5)
+        @order_item_6 = create(:order_item, item: @item_6, order: @order, sale_price: 5, quantity: 6)
+        @order_item_7 = create(:order_item, item: @item_7, order: @order, sale_price: 5, quantity: 3)
+        @order_item_8 = create(:order_item, item: @item_8, order: @order, sale_price: 5, quantity: 8, fulfillment_status: 1)
+        @order_item_9 = create(:order_item, item: @item_9, order: @order, sale_price: 5, quantity: 9, fulfillment_status: 1)
+        @order_item_10 = create(:order_item, item: @item_10, order: @order, sale_price: 5, quantity: 10, fulfillment_status: 1)
+      end
 
-    it '#in_stock?' do
-      Faker::UniqueGenerator.clear
-      @user = create(:user)
-      @merchant = create(:user, role: 1)
-      @item_1, @item_2, @item_3, @item_4, @item_5, @item_6, @item_7, @item_8, @item_9, @item_10 = create_list(:item, 10, user: @merchant, quantity: 5)
-      @order = create(:order, user: @user)
-      @order_item_1 = create(:order_item, item: @item_1, order: @order, sale_price: 5, quantity: 1)
-      @order_item_2 = create(:order_item, item: @item_2, order: @order, sale_price: 5, quantity: 2)
-      @order_item_3 = create(:order_item, item: @item_3, order: @order, sale_price: 5, quantity: 7)
-      @order_item_4 = create(:order_item, item: @item_4, order: @order, sale_price: 5, quantity: 4)
-      @order_item_5 = create(:order_item, item: @item_5, order: @order, sale_price: 5, quantity: 5)
-      @order_item_6 = create(:order_item, item: @item_6, order: @order, sale_price: 5, quantity: 6)
-      @order_item_7 = create(:order_item, item: @item_7, order: @order, sale_price: 5, quantity: 3)
-      @order_item_8 = create(:order_item, item: @item_8, order: @order, sale_price: 5, quantity: 8, fulfillment_status: 1)
-      @order_item_9 = create(:order_item, item: @item_9, order: @order, sale_price: 5, quantity: 9, fulfillment_status: 1)
-      @order_item_10 = create(:order_item, item: @item_10, order: @order, sale_price: 5, quantity: 10, fulfillment_status: 1)
+      it '#in_stock?' do
+        expect(@order_item_1.in_stock?).to eq(true)
+        expect(@order_item_2.in_stock?).to eq(true)
+        expect(@order_item_3.in_stock?).to eq(false)
+        expect(@order_item_4.in_stock?).to eq(true)
+        expect(@order_item_5.in_stock?).to eq(true)
+        expect(@order_item_6.in_stock?).to eq(false)
+        expect(@order_item_7.in_stock?).to eq(true)
+        expect(@order_item_8.in_stock?).to eq(false)
+        expect(@order_item_9.in_stock?).to eq(false)
+        expect(@order_item_10.in_stock?).to eq(false)
+      end
 
-      expect(@order_item_1.in_stock?).to eq(true)
-      expect(@order_item_2.in_stock?).to eq(true)
-      expect(@order_item_3.in_stock?).to eq(false)
-      expect(@order_item_4.in_stock?).to eq(true)
-      expect(@order_item_5.in_stock?).to eq(true)
-      expect(@order_item_6.in_stock?).to eq(false)
-      expect(@order_item_7.in_stock?).to eq(true)
-      expect(@order_item_8.in_stock?).to eq(false)
-      expect(@order_item_9.in_stock?).to eq(false)
-      expect(@order_item_10.in_stock?).to eq(false)
+      it "decrements in-stock item quantity" do
+        expect(@order_item_1.item.quantity).to eq(5)
+        expect(@order_item_1.fulfilled?).to eq(false)
+        @order_item_1.fulfill_order_item
+        expect(@order_item_1.item.quantity).to eq(4)
+        expect(@order_item_1.fulfilled?).to eq(true)
+
+        expect(@order_item_2.item.quantity).to eq(5)
+        expect(@order_item_2.fulfilled?).to eq(false)
+        @order_item_2.fulfill_order_item
+        expect(@order_item_2.item.quantity).to eq(3)
+        expect(@order_item_2.fulfilled?).to eq(true)
+
+        expect(@order_item_7.item.quantity).to eq(5)
+        expect(@order_item_7.fulfilled?).to eq(false)
+        @order_item_7.fulfill_order_item
+        expect(@order_item_7.item.quantity).to eq(2)
+        expect(@order_item_7.fulfilled?).to eq(true)
+
+        expect(@order_item_4.item.quantity).to eq(5)
+        expect(@order_item_4.fulfilled?).to eq(false)
+        @order_item_4.fulfill_order_item
+        expect(@order_item_4.item.quantity).to eq(1)
+        expect(@order_item_4.fulfilled?).to eq(true)
+
+        expect(@order_item_5.item.quantity).to eq(5)
+        expect(@order_item_5.fulfilled?).to eq(false)
+        @order_item_5.fulfill_order_item
+        expect(@order_item_5.item.quantity).to eq(0)
+        expect(@order_item_5.fulfilled?).to eq(true)
+      end
     end
   end
 

--- a/spec/models/order_items_spec.rb
+++ b/spec/models/order_items_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OrderItem, type: :model do
   end
 
   describe "Instance Methods" do
-    it "calculates a subtotal" do
+    it "#calculates a subtotal" do
       user = create(:user)
       order = create(:order, user: user)
       item1 = create(:item)
@@ -48,6 +48,35 @@ RSpec.describe OrderItem, type: :model do
       expect(oi2.quantity).to eq(2)
       expect(item2.quantity).to eq(7)
 
+    end
+
+    it '#in_stock?' do
+      Faker::UniqueGenerator.clear
+      @user = create(:user)
+      @merchant = create(:user, role: 1)
+      @item_1, @item_2, @item_3, @item_4, @item_5, @item_6, @item_7, @item_8, @item_9, @item_10 = create_list(:item, 10, user: @merchant, quantity: 5)
+      @order = create(:order, user: @user)
+      @order_item_1 = create(:order_item, item: @item_1, order: @order, sale_price: 5, quantity: 1)
+      @order_item_2 = create(:order_item, item: @item_2, order: @order, sale_price: 5, quantity: 2)
+      @order_item_3 = create(:order_item, item: @item_3, order: @order, sale_price: 5, quantity: 7)
+      @order_item_4 = create(:order_item, item: @item_4, order: @order, sale_price: 5, quantity: 4)
+      @order_item_5 = create(:order_item, item: @item_5, order: @order, sale_price: 5, quantity: 5)
+      @order_item_6 = create(:order_item, item: @item_6, order: @order, sale_price: 5, quantity: 6)
+      @order_item_7 = create(:order_item, item: @item_7, order: @order, sale_price: 5, quantity: 3)
+      @order_item_8 = create(:order_item, item: @item_8, order: @order, sale_price: 5, quantity: 8, fulfillment_status: 1)
+      @order_item_9 = create(:order_item, item: @item_9, order: @order, sale_price: 5, quantity: 9, fulfillment_status: 1)
+      @order_item_10 = create(:order_item, item: @item_10, order: @order, sale_price: 5, quantity: 10, fulfillment_status: 1)
+
+      expect(@order_item_1.in_stock?).to eq(true)
+      expect(@order_item_2.in_stock?).to eq(true)
+      expect(@order_item_3.in_stock?).to eq(false)
+      expect(@order_item_4.in_stock?).to eq(true)
+      expect(@order_item_5.in_stock?).to eq(true)
+      expect(@order_item_6.in_stock?).to eq(false)
+      expect(@order_item_7.in_stock?).to eq(true)
+      expect(@order_item_8.in_stock?).to eq(false)
+      expect(@order_item_9.in_stock?).to eq(false)
+      expect(@order_item_10.in_stock?).to eq(false)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Order, type: :model do
       @user = create(:user)
       @merchant = create(:user, role: 1)
 
-      @item_1, @item_2, @item_3, @item_4, @item_5, @item_6, @item_7, @item_8, @item_9, @item_10 = create_list(:item, 10, user: @merchant)
+      @item_1, @item_2, @item_3, @item_4, @item_5, @item_6, @item_7, @item_8, @item_9, @item_10 = create_list(:item, 10, user: @merchant, quantity: 5)
 
       @order = create(:order, user: @user)
 
@@ -113,6 +113,19 @@ RSpec.describe Order, type: :model do
       @order.order_items.each do |order_item|
         expect(order_item.fulfillment_status).to eq("unfulfilled")
       end
+    end
+
+    it '#in_stock?' do
+      expect(@order_item_1.in_stock?).to eq(true)
+      expect(@order_item_2.in_stock?).to eq(true)
+      expect(@order_item_3.in_stock?).to eq(true)
+      expect(@order_item_4.in_stock?).to eq(true)
+      expect(@order_item_5.in_stock?).to eq(true)
+      expect(@order_item_6.in_stock?).to eq(true)
+      expect(@order_item_7.in_stock?).to eq(true)
+      expect(@order_item_8.in_stock?).to eq(true)
+      expect(@order_item_9.in_stock?).to eq(true)
+      expect(@order_item_10.in_stock?).to eq(true)
     end
 
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -115,19 +115,6 @@ RSpec.describe Order, type: :model do
       end
     end
 
-    it '#in_stock?' do
-      expect(@order_item_1.in_stock?).to eq(true)
-      expect(@order_item_2.in_stock?).to eq(true)
-      expect(@order_item_3.in_stock?).to eq(true)
-      expect(@order_item_4.in_stock?).to eq(true)
-      expect(@order_item_5.in_stock?).to eq(true)
-      expect(@order_item_6.in_stock?).to eq(true)
-      expect(@order_item_7.in_stock?).to eq(true)
-      expect(@order_item_8.in_stock?).to eq(true)
-      expect(@order_item_9.in_stock?).to eq(true)
-      expect(@order_item_10.in_stock?).to eq(true)
-    end
-
   end
 
 end


### PR DESCRIPTION
Closes #7 

As a merchant
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is equal to or less than my current inventory quantity for that item
And I have not already "fulfilled" that item:
- Then I see a button or link to "fulfill" that item
- When I click on that link or button I am returned to the order show page
- I see the item is now fulfilled
- I also see a flash message indicating that I have fulfilled that item
- My inventory quantity is permanently reduced by the user's desired quantity

If I have already fulfilled this item, I see text indicating such.